### PR TITLE
Update MANIFEST.in

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,4 +1,4 @@
-include README.rst
+include README.md
 include setup.py
 recursive-include adminsortable/ *
 recursive-include adminsortable/static *


### PR DESCRIPTION
Fix MANIFEST.in to include new readme. 
Installing 0.2.0 from PyPI is currently broken since it can't find the readme, this should fix this.
