### PR TITLE
Fix CustomInlineFormSet to allow customization

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -216,11 +216,10 @@ class CustomInlineFormSet(BaseInlineFormSet):
         except (AttributeError, IndexError):
             raise ImproperlyConfigured(u'Model %s.%s requires a list or tuple "ordering" in its Meta class'
                                        % (self.model.__module__, self.model.__name__))
-        form = modelform_factory(self.model, widgets={ self.default_order_field: HiddenInput() })
-        form.base_fields[self.default_order_field].is_hidden = True
-        form.base_fields[self.default_order_field].required = False
-        self.form = form
         super(CustomInlineFormSet, self).__init__(*args, **kwargs)
+        self.form.base_fields[self.default_order_field].is_hidden = True
+        self.form.base_fields[self.default_order_field].required = False
+        self.form.base_fields[self.default_order_field].widget = HiddenInput()
 
     def save_new(self, form, commit=True):
         """


### PR DESCRIPTION
This changes does allows to not override the form generated by the admin and just patches the `default_order_field` field. This permits further customization in the modeladmin (e.g.: by using `formfield_for_dbfield` method) and allows better integration with other django applicatons (e.g.: django-admin-enhancer)
