### PR TITLE
Fixed the way that the CustomInlineFormset class gets used.

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -240,6 +240,8 @@ class CustomInlineFormSet(BaseInlineFormSet):
 
 
 class SortableInlineAdminMixin(SortableAdminBase):
+    formset = CustomInlineFormSet
+    
     def __init__(self, parent_model, admin_site):
         version = (VERSION[0] == 1 and VERSION[1] <= 5) and '1.5' or '1.6'
         if isinstance(self, admin.StackedInline):
@@ -253,4 +255,3 @@ class SortableInlineAdminMixin(SortableAdminBase):
                                        % (self.__module__, self.__class__))
         self.Media.css['all'] += ('adminsortable/css/sortable.css',)
         super(SortableInlineAdminMixin, self).__init__(parent_model, admin_site)
-        self.formset = inlineformset_factory(parent_model, self.model, formset=CustomInlineFormSet)


### PR DESCRIPTION
Rather than executing `inlineformset_factory()` in the constructor,
`SortableInlineAdminMixin` now specifies the `formset` class attribute just
like `admin.InlineModelAdmin` does it. Since users already have to put the
`SortableInlineAdminMixin` before `admin.TabularInline` in the class definition,
this means that `admin.InlineModelAdmin.formset` gets overridden, letting
`admin.InlineModelAdmin.get_formset()` do it's job as usual.

This fix is needed because the way it used to work would cause a bunch of 
important settings in the user's `XYZInline` class, like `fk_name`, to be ignored.
