### PR TITLE
Optional disabling of admin actions

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -86,7 +86,7 @@ class SortableAdminMixin(SortableAdminBase):
             self.order_by = '-' + self.default_order_field
         else:
             self.enable_sorting = False
-        if self.enable_sorting:
+        if self.enable_sorting and not getattr(self, 'disable_sorting_actions', False):
             self.actions += ['move_to_prev_page', 'move_to_next_page', 'move_to_first_page', 'move_to_last_page']
         return super(SortableAdminMixin, self).get_changelist(request, **kwargs)
 


### PR DESCRIPTION
Allows you to avoid adding extra admin actions by setting:

```
disable_sorting_actions = True
```

on the ModelAdmin.

From a UX perspective I would hesitate to use admin-sortable where the changelist was long enough to be paginated. In that scenario it's a lot harder to understand what's going on and I like my admin to be simple and usable for non-experts. sortable2 always adds admin actions for handling sorting paginated lists even when the list isn't paginated. To complicate the UX with admin actions that won't be used in many cases seems to be a bad deal for end users.

Ideally the admin actions would also only be added if the changelist was actually long enough to trigger pagination but allowing disabling of actions manually via an attribute is a good start.
