### PR TITLE
Remove change_list template, set path in JS

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -65,8 +65,6 @@ class SortableAdminMixin(SortableAdminBase):
             self.exclude = [self.default_order_field]
         elif not self.exclude or self.default_order_field != self.exclude[0]:
             self.exclude = [self.default_order_field] + self.exclude
-        if not getattr(self, 'change_list_template', None):
-            self.change_list_template = 'adminsortable/change_list.html'
         if not self.list_display_links:
             self.list_display_links = self.list_display[0]
         self._add_reorder_method()

--- a/adminsortable/static/adminsortable/js/list-sortable.js
+++ b/adminsortable/static/adminsortable/js/list-sortable.js
@@ -18,7 +18,7 @@ jQuery.extend({
 
 // make list view sortable
 jQuery(function($) {
-	var sortable_update_url = $('#adminsortable_update_url').attr('href');
+	var sortable_update_url = window.location.pathname + 'adminsortable_update/';
 	var startorder, endorder;
 	$('#result_list').sortable({
 		handle: 'div.drag',

--- a/adminsortable/templates/adminsortable/change_list.html
+++ b/adminsortable/templates/adminsortable/change_list.html
@@ -1,6 +1,0 @@
-{% extends "admin/change_list.html" %}
-
-{% block content %}
-	{{ block.super }}
-	<a id="adminsortable_update_url" href="adminsortable_update/"></a>
-{% endblock %}


### PR DESCRIPTION
admin-sortable wasn't working on my list page and it took me a while to figure out why: I was using a custom `template_change_list`. Since the admin-sortable one is only used to set a hard-coded path, I moved that definition into the JS. This should make admin-sortable more flexible with regards to templates.

Do let me know if this is suboptimal, I might be missing something I haven't considered.