### PR TITLE
Use field verbose_name in tabular inline template instead of 'Sort'

### DIFF
--- a/adminsortable/admin.py
+++ b/adminsortable/admin.py
@@ -50,6 +50,16 @@ class SortableAdminBase(object):
                 # other packages may pollute the import search path with 'cms'
                 pass
 
+    def order_field_verbose_name(self):
+
+        model = self.model
+        try:
+            default_order_field = self.model._meta.ordering[0].lstrip('-')
+        except (AttributeError, IndexError):
+            raise ImproperlyConfigured('Model {0}.{1} requires a list or tuple "ordering" in its Meta class'.format(model.__module__, model.__name__))
+
+        return model._meta.get_field_by_name(default_order_field)[0].verbose_name
+
 
 class SortableAdminMixin(SortableAdminBase):
     PREV, NEXT, FIRST, LAST = range(4)
@@ -127,7 +137,7 @@ class SortableAdminMixin(SortableAdminBase):
             return html
 
         setattr(func, 'allow_tags', True)
-        setattr(func, 'short_description', _('Sort'))
+        setattr(func, 'short_description', self.order_field_verbose_name())
         setattr(func, 'admin_order_field', self.default_order_field)
         setattr(self, '_reorder', MethodType(func, self))
 

--- a/adminsortable/templates/adminsortable/tabular-1.5.html
+++ b/adminsortable/templates/adminsortable/tabular-1.5.html
@@ -6,7 +6,7 @@
    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
-     <thead><tr><th>{% trans "Sort" %}</th>
+     <thead><tr><th>{{ inline_admin_formset.opts.order_field_verbose_name|capfirst }}</th>
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}

--- a/adminsortable/templates/adminsortable/tabular-1.6.html
+++ b/adminsortable/templates/adminsortable/tabular-1.6.html
@@ -6,7 +6,7 @@
    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>
-     <thead><tr><th>{% trans "Sort" %}</th>
+     <thead><tr><th>{{ inline_admin_formset.opts.order_field_verbose_name|capfirst }}</th>
      {% for field in inline_admin_formset.fields %}
        {% if not field.widget.is_hidden %}
          <th{% if forloop.first %} colspan="2"{% endif %}{% if field.required %} class="required"{% endif %}>{{ field.label|capfirst }}


### PR DESCRIPTION
Instead of hard coding column name in adminsortable,  we use the field verbose name as defined in models.py.
