### PR TITLE
Column selection

### DIFF
--- a/adminsortable/static/adminsortable/css/sortable.css
+++ b/adminsortable/static/adminsortable/css/sortable.css
@@ -1,5 +1,5 @@
 /* styles for list view */
-#result_list thead th:nth-child(2) {
+#result_list thead th:first-child {
 	width: 50px;
 }
 


### PR DESCRIPTION
We noticed that the column added for sortable is always the first, but the css resizes the second column. This might be a bug so proposing a fix upstream.