### PR TITLE
Changelist page: impossible to drag-and-drop into the very top of the list

### DIFF
--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -29,6 +29,7 @@ jQuery(function($) {
 		scroll: true,
 		cursor: 'ns-resize',
 		containment: $('#result_list tbody'),
+		tolerance: 'pointer',
 		start: function(event, dragged_rows) {
 			$(this).find('thead tr th').each(function(index) {
 				$(dragged_rows.item.context.childNodes[index]).width($(this).width() - 10);


### PR DESCRIPTION
As per subject line: I could move items from any row to any other row, **except** that I could not drop items at the top of the list.

**Note**: the project that I am currently working on uses 'djangocms-admin-style'; there *might* be interference between this and django-admin-sortable2. However, as the setting that I have changed seems to have no side-effects, I would suggest that it's a worthwhile change in any case.