### PR TITLE
Fix items ordering when order field has an initial default value

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -273,9 +273,12 @@ class CustomInlineFormSet(BaseInlineFormSet):
         """
         New objects do not have a valid value in their ordering field. On object save, add an order
         bigger than all other order fields for the current parent_model.
+        Strange behaviour when field has a default, this might be evaluated on new object and the value
+        will be not None, but the default value.
         """
         obj = super(CustomInlineFormSet, self).save_new(form, commit=False)
-        if getattr(obj, self.default_order_field, None) is None:
+        default_order_field = getattr(obj, self.default_order_field, None)
+        if default_order_field is None or default_order_field >= 0:
             query_set = self.model.objects.filter(**{self.fk.get_attname(): self.instance.pk})
             max_order = query_set.aggregate(max_order=Max(self.default_order_field))['max_order'] or 0
             setattr(obj, self.default_order_field, max_order + 1)


### PR DESCRIPTION
It doesn't happen with django, but I have this behavior when I use the ```adminsortable2``` with django-cms: the new record has a value in field ```my_order``` and the ```if``` check is missed, in fact default_order_field has a value greater than or equal to 0.
It could work if a user wants to reuse an existing order field, this patch it should be a solution. 
