### PR TITLE
Fix access of a non init enable_sorting attribute in the media property

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -115,7 +115,7 @@ class SortableAdminMixin(SortableAdminBase):
     @property
     def media(self):
         m = super(SortableAdminMixin, self).media
-        if self.enable_sorting:
+        if hasattr(self, 'enable_sorting') and self.enable_sorting:
             m = m + widgets.Media(js=('adminsortable2/js/list-sortable.js',))
         return m
 


### PR DESCRIPTION
Bug: It looks like that the media property of SortableAdminMixin can be call in the admin change_form pages and using the self.enable_sorting attribute which can be not initialize(it's init only in the get_changelist method).
In this case the code stop on it and die silently so some of the rest of admin media are not load (like default admin js)

How to reproduce it: Just with the testapp go to "add a book" admin page, restart the server and refresh the web page. And then some of the admin media are not anymore in the <head/> which cause for example the fk add another popup js to not work.

Fix : To fix it i just check that attribute exist but maybe we can just set enable_sorting to False int the __init__?

