### PR TITLE
Django 1.9 support, handling in list-sortable.js, disable reordering when list is unsorted, moving arbitrary number of pages.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,8 @@ python:
 env:
   - DJANGO="django<1.7"
   - DJANGO="django<1.8"
-  - DJANGO="django==1.8a1"
+  - DJANGO="django<1.9"
+  - DJANGO="django==1.9b1"
 
 install:
   - pip install -q $DJANGO

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -85,7 +85,7 @@ class SortableAdminMixin(SortableAdminBase):
     def get_actions(self, request):
         actions = super(SortableAdminMixin, self).get_actions(request)
         paginator = self.get_paginator(request, self.get_queryset(request), self.list_per_page)
-        if len(paginator.page_range) > 1 and 'all' not in request.GET:
+        if len(paginator.page_range) > 1 and 'all' not in request.GET and self.enable_sorting:
             # add actions for moving items to other pages
             move_actions = []
             cur_page = int(request.GET.get('p', 0)) + 1
@@ -103,7 +103,7 @@ class SortableAdminMixin(SortableAdminBase):
 
     def get_changelist(self, request, **kwargs):
         order = self._get_order_direction(request)
-        if not order or order == '1':
+        if order == '1':
             self.enable_sorting = True
             self.order_by = self.default_order_field
         elif order == '-1':
@@ -180,7 +180,7 @@ class SortableAdminMixin(SortableAdminBase):
     move_to_last_page.short_description = _('Move selected to last page')
 
     def _get_order_direction(self, request):
-        return request.POST.get('o', request.GET.get('o', '')).split('.')[0]
+        return request.POST.get('o', request.GET.get('o', '1')).split('.')[0]
 
     def _move_item(self, request, startorder, endorder):
         if self._get_order_direction(request) != '-1':

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -4,7 +4,7 @@ from types import MethodType
 from django import VERSION
 from django.utils.translation import ugettext_lazy as _
 from django.conf import settings
-from django.conf.urls import patterns, url
+from django.conf.urls import url
 from django.core.exceptions import ImproperlyConfigured
 from django.core.paginator import EmptyPage
 from django.db import transaction
@@ -77,9 +77,9 @@ class SortableAdminMixin(SortableAdminBase):
         self.list_display = ['_reorder'] + list(self.list_display)
 
     def get_urls(self):
-        my_urls = patterns('',
+        my_urls = [
             url(r'^adminsortable2_update/$', self.admin_site.admin_view(self.update), name='sortable_update'),
-        )
+        ]
         return my_urls + super(SortableAdminMixin, self).get_urls()
 
     def get_actions(self, request):
@@ -88,7 +88,7 @@ class SortableAdminMixin(SortableAdminBase):
         if len(paginator.page_range) > 1:
             # add actions for moving items to other pages
             move_actions = []
-            cur_page = int(request.REQUEST.get('p', 0)) + 1
+            cur_page = int(request.GET.get('p', 0)) + 1
             if len(paginator.page_range) > 2 and cur_page > paginator.page_range[1]:
                 move_actions.append('move_to_first_page')
             if cur_page > paginator.page_range[0]:
@@ -180,7 +180,7 @@ class SortableAdminMixin(SortableAdminBase):
     move_to_last_page.short_description = _('Move selected to last page')
 
     def _get_order_direction(self, request):
-        return request.REQUEST.get('o', '').split('.')[0]
+        return request.POST.get('o', request.GET.get('o', '')).split('.')[0]
 
     def _move_item(self, request, startorder, endorder):
         if self._get_order_direction(request) != '-1':
@@ -228,7 +228,7 @@ class SortableAdminMixin(SortableAdminBase):
             return
         objects = self.model.objects.order_by(self.order_by)
         paginator = self.paginator(objects, self.list_per_page)
-        page = paginator.page(int(request.REQUEST.get('p', 0)) + 1)
+        page = paginator.page(int(request.GET.get('p', 0)) + 1)
         try:
             if method == self.PREV:
                 page = paginator.page(page.previous_page_number())

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -85,7 +85,7 @@ class SortableAdminMixin(SortableAdminBase):
     def get_actions(self, request):
         actions = super(SortableAdminMixin, self).get_actions(request)
         paginator = self.get_paginator(request, self.get_queryset(request), self.list_per_page)
-        if len(paginator.page_range) > 1:
+        if len(paginator.page_range) > 1 and 'all' not in request.GET:
             # add actions for moving items to other pages
             move_actions = []
             cur_page = int(request.GET.get('p', 0)) + 1

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -61,6 +61,7 @@ class SortableAdminMixin(SortableAdminBase):
     BACK, FORWARD, FIRST, LAST, EXACT = range(5)
     enable_sorting = False
     action_form = MovePageActionForm
+    change_list_template = 'adminsortable2/change_list.html'
 
     def __init__(self, model, admin_site):
         try:

--- a/adminsortable2/management/commands/reorder.py
+++ b/adminsortable2/management/commands/reorder.py
@@ -1,7 +1,12 @@
 # -*- coding: utf-8 -*-
+import django
 from django.core.management.base import BaseCommand, CommandError
-from django.utils.module_loading import import_by_path
 from django.core import exceptions
+
+if django.VERSION[:2] < (1, 7):
+    from django.utils.module_loading import import_by_path as import_string
+else:
+    from django.utils.module_loading import import_string
 
 
 class Command(BaseCommand):
@@ -11,7 +16,7 @@ class Command(BaseCommand):
     def handle(self, *args, **options):
         for modelname in args:
             try:
-                Model = import_by_path(modelname)
+                Model = import_string(modelname)
             except exceptions.ImproperlyConfigured:
                 raise CommandError('Unable to load model "%s"' % modelname)
             if not hasattr(Model._meta, 'ordering') or len(Model._meta.ordering) == 0:

--- a/adminsortable2/static/adminsortable2/css/sortable.css
+++ b/adminsortable2/static/adminsortable2/css/sortable.css
@@ -1,3 +1,8 @@
+/* hide action input fields */
+#changelist-form-step, #changelist-form-page {
+	display: none;
+}
+
 /* styles for list view */
 #result_list thead th:nth-child(2) {
 	width: 50px;

--- a/adminsortable2/static/adminsortable2/css/sortable.css
+++ b/adminsortable2/static/adminsortable2/css/sortable.css
@@ -1,6 +1,7 @@
 /* hide action input fields */
 #changelist-form-step, #changelist-form-page {
 	display: none;
+	margin-left: 0.5em;
 }
 
 /* styles for list view */

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -38,6 +38,7 @@ jQuery(function($) {
 		},
 		stop: function(event, dragged_rows) {
 			var $result_list = $(this);
+			var ordering = $.getQueryParam('o');
 			$result_list.find('tbody tr').each(function(index) {
 				$(this).removeClass('row1 row2').addClass(index % 2 ? 'row2' : 'row1');
 			}).each(function() {
@@ -46,13 +47,15 @@ jQuery(function($) {
 					return false;
 				endorder = untilorder;
 			});
-			if (startorder === endorder + 1)
+			if (ordering === '1' || ordering === undefined && startorder === endorder + 1)
+				return;
+			else if(ordering === '-1' && startorder === endorder - 1)
 				return;
 			$.ajax({
 				url: sortable_update_url,
 				type: 'POST',
 				data: {
-					o: $.getQueryParam('o'),
+					o: ordering,
 					startorder: startorder,
 					endorder: endorder,
 					csrfmiddlewaretoken: csrfvalue

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -44,16 +44,17 @@ jQuery(function($) {
 			});
 			endindex = dragged_rows.item.index()
 
-			startorder = $(dragged_rows.item.context).find('div.drag').attr('order');
 			if (startindex == endindex) return;
 			else if (endindex == 0) {
-				if (ordering === '1' || ordering === undefined)
-					endorder = parseInt($(dragged_rows.item.context.nextElementSibling).find('div.drag').attr('order')) - 1;
-				else
+				if (ordering.split('.')[0] === '-1')
 					endorder = parseInt($(dragged_rows.item.context.nextElementSibling).find('div.drag').attr('order')) + 1;
+				else
+					endorder = parseInt($(dragged_rows.item.context.nextElementSibling).find('div.drag').attr('order')) - 1;
 			} else {
 				endorder = $(dragged_rows.item.context.previousElementSibling).find('div.drag').attr('order');
 			}
+			startorder = $(dragged_rows.item.context).find('div.drag').attr('order');
+
 			$.ajax({
 				url: sortable_update_url,
 				type: 'POST',

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -19,8 +19,9 @@ jQuery.extend({
 // make list view sortable
 jQuery(function($) {
 	var sortable_update_url = $('#adminsortable_update_url').attr('href') || 'adminsortable2_update/';
-	var startorder, endorder;
+	var startindex, startorder, endindex, endorder;
 	var csrfvalue = $('form').find('input[name="csrfmiddlewaretoken"]').val();
+	var ordering = $.getQueryParam('o');
 
 	$('#result_list').sortable({
 		handle: 'div.drag',
@@ -34,23 +35,25 @@ jQuery(function($) {
 			$(this).find('thead tr th').each(function(index) {
 				$(dragged_rows.item.context.childNodes[index]).width($(this).width() - 10);
 			});
-			startorder = parseInt($(dragged_rows.item.context).find('div.drag').attr('order'));
+			startindex = dragged_rows.item.index();
 		},
 		stop: function(event, dragged_rows) {
 			var $result_list = $(this);
-			var ordering = $.getQueryParam('o');
 			$result_list.find('tbody tr').each(function(index) {
 				$(this).removeClass('row1 row2').addClass(index % 2 ? 'row2' : 'row1');
-			}).each(function() {
-				var untilorder = parseInt($(this).find('div.drag').attr('order'));
-				if (startorder === untilorder)
-					return false;
-				endorder = untilorder;
 			});
-			if (ordering === '1' || ordering === undefined && startorder === endorder + 1)
-				return;
-			else if(ordering === '-1' && startorder === endorder - 1)
-				return;
+			endindex = dragged_rows.item.index()
+
+			var startorder = parseInt($(dragged_rows.item.context).find('div.drag').attr('order'));
+			if (startindex == endindex) return;
+			else if (endindex == 0) {
+				if (ordering === '1' || ordering === undefined)
+					endorder = parseInt($(dragged_rows.item.context.nextElementSibling).find('div.drag').attr('order')) - 1;
+				else
+					endorder = parseInt($(dragged_rows.item.context.nextElementSibling).find('div.drag').attr('order')) + 1;
+			} else {
+				endorder = $(dragged_rows.item.context.previousElementSibling).find('div.drag').attr('order');
+			}
 			$.ajax({
 				url: sortable_update_url,
 				type: 'POST',

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -22,6 +22,8 @@ jQuery(function($) {
 	var startindex, startorder, endindex, endorder;
 	var csrfvalue = $('form').find('input[name="csrfmiddlewaretoken"]').val();
 	var ordering = $.getQueryParam('o');
+	if (ordering === undefined)
+		ordering = '1';
 
 	$('#result_list').sortable({
 		handle: 'div.drag',

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -44,7 +44,7 @@ jQuery(function($) {
 			});
 			endindex = dragged_rows.item.index()
 
-			var startorder = parseInt($(dragged_rows.item.context).find('div.drag').attr('order'));
+			startorder = $(dragged_rows.item.context).find('div.drag').attr('order');
 			if (startindex == endindex) return;
 			else if (endindex == 0) {
 				if (ordering === '1' || ordering === undefined)

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -18,7 +18,6 @@ jQuery.extend({
 
 // make list view sortable
 jQuery(function($) {
-	var sortable_update_url = $('#adminsortable_update_url').attr('href') || 'adminsortable2_update/';
 	var startindex, startorder, endindex, endorder;
 	var csrfvalue = $('form').find('input[name="csrfmiddlewaretoken"]').val();
 	var ordering = $.getQueryParam('o');
@@ -87,25 +86,26 @@ jQuery(function($) {
 	var $step_field = $('#changelist-form-step');
 	var $page_field = $('#changelist-form-page');
 
-	var page = $.getQueryParam('p');
-	if (page === undefined)
-		$page_field.val('2');
-	else {
-		// TODO: Is there a better way than this hack?
-		var $last_page = $('#changelist-form .paginator .end');
-		if ($last_page.length == 0)
-			$last_page = $('#changelist-form .paginator .this-page');
-		var total_pages = parseInt($last_page.text());
-
-		page = parseInt(page) + 1;
-		if (page == total_pages)
-			$page_field.val(page - 1);
-		else
-			$page_field.val(page + 1);
+	if (sortable_current_page == sortable_total_pages) {
+		$page_field.attr('max', sortable_total_pages - 1);
+		$page_field.val(sortable_current_page - 1);
+	} else {
+		$page_field.attr('max', sortable_total_pages);
+		$page_field.val(sortable_current_page + 1)
 	}
+	if(sortable_current_page == 1)
+		$page_field.attr('min', 2);
+	else
+		$page_field.attr('min', 1);
+
+	$step_field.attr('min', 1);
 
 	$('#changelist-form').find('select[name="action"]').change(function() {
 		if (['move_to_back_page', 'move_to_forward_page'].indexOf($(this).val()) != -1) {
+			if ($(this).val() == 'move_to_forward_page')
+				$step_field.attr('max', sortable_total_pages - sortable_current_page);
+			else
+				$step_field.attr('max', sortable_current_page - 1);
 			$step_field.show();
 		} else {
 			$step_field.hide();

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -79,3 +79,39 @@ jQuery(function($) {
 	});
 	$('#result_list, tbody, tr, td, th').disableSelection();
 });
+
+// Show and hide the step input field
+jQuery(function($) {
+	var $step_field = $('#changelist-form-step');
+	var $page_field = $('#changelist-form-page');
+
+	var page = $.getQueryParam('p');
+	if (page === undefined)
+		$page_field.val('2');
+	else {
+		// TODO: Is there a better way than this hack?
+		var $last_page = $('#changelist-form .paginator .end');
+		if ($last_page.length == 0)
+			$last_page = $('#changelist-form .paginator .this-page');
+		var total_pages = parseInt($last_page.text());
+
+		page = parseInt(page) + 1;
+		if (page == total_pages)
+			$page_field.val(page - 1);
+		else
+			$page_field.val(page + 1);
+	}
+
+	$('#changelist-form').find('select[name="action"]').change(function() {
+		if (['move_to_back_page', 'move_to_forward_page'].indexOf($(this).val()) != -1) {
+			$step_field.show();
+		} else {
+			$step_field.hide();
+		}
+		if ($(this).val() == 'move_to_exact_page') {
+			$page_field.show();
+		} else {
+			$page_field.hide();
+		}
+	});
+});

--- a/adminsortable2/templates/adminsortable2/change_list.html
+++ b/adminsortable2/templates/adminsortable2/change_list.html
@@ -1,6 +1,10 @@
 {% extends "admin/change_list.html" %}
 
-{% block content %}
-	{{ block.super }}
-	<a id="adminsortable_update_url" href="adminsortable_update/"></a>
+{% block extrahead %}
+    {{ block.super }}
+    <script type="text/javascript">
+        var sortable_update_url = '{% url 'admin:sortable_update' %}';
+        var sortable_current_page = {{ cl.page_num | add:'1' }};
+        var sortable_total_pages = {{ cl.paginator.num_pages }};
+    </script>
 {% endblock %}

--- a/example/testapp/settings.py
+++ b/example/testapp/settings.py
@@ -1,4 +1,5 @@
 # Django settings for unit test project.
+import django
 
 DEBUG = True
 
@@ -32,17 +33,34 @@ STATIC_ROOT = '/home/static/'
 # Example: "http://media.lawrence.com/static/"
 STATIC_URL = '/static/'
 
+if django.VERSION[:2] < (1, 8):
 # List of callables that know how to import templates from various sources.
-TEMPLATE_LOADERS = (
-    'django.template.loaders.filesystem.Loader',
-    'django.template.loaders.app_directories.Loader',
-)
+    TEMPLATE_LOADERS = (
+        'django.template.loaders.filesystem.Loader',
+        'django.template.loaders.app_directories.Loader',
+    )
 
-TEMPLATE_DIRS = (
-    # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
-    # Always use forward slashes, even on Windows.
-    # Don't forget to use absolute paths, not relative paths.
-)
+    TEMPLATE_DIRS = (
+        # Put strings here, like "/home/html/django_templates" or "C:/www/django/templates".
+        # Always use forward slashes, even on Windows.
+        # Don't forget to use absolute paths, not relative paths.
+    )
+else:
+    TEMPLATES = [
+        {
+            'BACKEND': 'django.template.backends.django.DjangoTemplates',
+            'DIRS': [],
+            'APP_DIRS': True,
+            'OPTIONS': {
+                'context_processors': [
+                    'django.template.context_processors.debug',
+                    'django.template.context_processors.request',
+                    'django.contrib.auth.context_processors.auth',
+                    'django.contrib.messages.context_processors.messages',
+                ],
+            },
+        },
+    ]
 
 INSTALLED_APPS = (
     'django.contrib.auth',

--- a/example/testapp/tests/test_sortable.py
+++ b/example/testapp/tests/test_sortable.py
@@ -126,7 +126,7 @@ class SortableBookTestCase(TestCase):
     def test_bulkMovePrevFromFirstPage(self):
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 14)
         self.assertEqual(SortableBook.objects.get(pk=15).my_order, 15)
-        post_data = {'action': ['move_to_prev_page'], '_selected_action': [14, 15]}
+        post_data = {'action': ['move_to_back_page'], 'step': 1, '_selected_action': [14, 15]}
         self.client.post(self.bulk_update_url, post_data)
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 14)
         self.assertEqual(SortableBook.objects.get(pk=15).my_order, 15)
@@ -135,7 +135,7 @@ class SortableBookTestCase(TestCase):
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=18).my_order, 18)
         self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
-        post_data = {'action': ['move_to_prev_page'], '_selected_action': [17, 18, 19]}
+        post_data = {'action': ['move_to_back_page'], 'step': 1, '_selected_action': [17, 18, 19]}
         self.client.post(self.bulk_update_url + '?p=1', post_data)
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 1)
         self.assertEqual(SortableBook.objects.get(pk=18).my_order, 2)
@@ -144,7 +144,7 @@ class SortableBookTestCase(TestCase):
     def test_bulkMoveNextPage(self):
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 14)
         self.assertEqual(SortableBook.objects.get(pk=10).my_order, 10)
-        post_data = {'action': ['move_to_next_page'], '_selected_action': [14, 10]}
+        post_data = {'action': ['move_to_forward_page'], 'step': 1, '_selected_action': [14, 10]}
         self.client.post(self.bulk_update_url + '?p=1', post_data)
         self.assertEqual(SortableBook.objects.get(pk=10).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 18)
@@ -164,6 +164,30 @@ class SortableBookTestCase(TestCase):
         self.client.post(self.bulk_update_url + '?p=2', post_data)
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 1)
         self.assertEqual(SortableBook.objects.get(pk=20).my_order, 2)
+
+    def test_bulkMoveBackTwoPages(self):
+        self.assertEqual(SortableBook.objects.get(pk=17).my_order, 17)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
+        post_data = {'action': ['move_to_back_page'], 'step': 2, '_selected_action': [17, 20]}
+        self.client.post(self.bulk_update_url + '?p=2', post_data)
+        self.assertEqual(SortableBook.objects.get(pk=17).my_order, 1)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 2)
+
+    def test_bulkMoveForwardTwoPages(self):
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 1)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 6)
+        post_data = {'action': ['move_to_forward_page'], 'step': 2, '_selected_action': [1, 6]}
+        self.client.post(self.bulk_update_url, post_data)
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 17)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 18)
+
+    def test_bulkMoveToSpecificPage(self):
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 1)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 6)
+        post_data = {'action': ['move_to_exact_page'], 'page': 3, '_selected_action': [1, 6]}
+        self.client.post(self.bulk_update_url, post_data)
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 17)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 18)
 
     def testFilledBookShelf(self):
         self.assertEqual(SortableBook.objects.count(), 20,

--- a/example/testapp/tests/test_sortable.py
+++ b/example/testapp/tests/test_sortable.py
@@ -135,8 +135,8 @@ class SortableBookTestCase(TestCase):
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=18).my_order, 18)
         self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
-        post_data = {'p': 1, 'action': ['move_to_prev_page'], '_selected_action': [17, 18, 19]}
-        self.client.post(self.bulk_update_url, post_data)
+        post_data = {'action': ['move_to_prev_page'], '_selected_action': [17, 18, 19]}
+        self.client.post(self.bulk_update_url + '?p=1', post_data)
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 1)
         self.assertEqual(SortableBook.objects.get(pk=18).my_order, 2)
         self.assertEqual(SortableBook.objects.get(pk=19).my_order, 3)
@@ -144,8 +144,8 @@ class SortableBookTestCase(TestCase):
     def test_bulkMoveNextPage(self):
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 14)
         self.assertEqual(SortableBook.objects.get(pk=10).my_order, 10)
-        post_data = {'p': 1, 'action': ['move_to_next_page'], '_selected_action': [14, 10]}
-        self.client.post(self.bulk_update_url, post_data)
+        post_data = {'action': ['move_to_next_page'], '_selected_action': [14, 10]}
+        self.client.post(self.bulk_update_url + '?p=1', post_data)
         self.assertEqual(SortableBook.objects.get(pk=10).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 18)
 
@@ -160,8 +160,8 @@ class SortableBookTestCase(TestCase):
     def test_bulkMoveFirstPage(self):
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
-        post_data = {'p': 2, 'action': ['move_to_first_page'], '_selected_action': [17, 20]}
-        self.client.post(self.bulk_update_url, post_data)
+        post_data = {'action': ['move_to_first_page'], '_selected_action': [17, 20]}
+        self.client.post(self.bulk_update_url + '?p=2', post_data)
         self.assertEqual(SortableBook.objects.get(pk=17).my_order, 1)
         self.assertEqual(SortableBook.objects.get(pk=20).my_order, 2)
 

--- a/example/testapp/tests/test_sortable.py
+++ b/example/testapp/tests/test_sortable.py
@@ -141,6 +141,14 @@ class SortableBookTestCase(TestCase):
         self.assertEqual(SortableBook.objects.get(pk=18).my_order, 2)
         self.assertEqual(SortableBook.objects.get(pk=19).my_order, 3)
 
+    def test_bulkMoveForwardFromLastPage(self):
+        self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
+        post_data = {'action': ['move_to_forward_page'], 'step': 1, '_selected_action': [19, 20]}
+        self.client.post(self.bulk_update_url + '?p=2', post_data)
+        self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
+
     def test_bulkMoveNextPage(self):
         self.assertEqual(SortableBook.objects.get(pk=14).my_order, 14)
         self.assertEqual(SortableBook.objects.get(pk=10).my_order, 10)
@@ -181,6 +189,14 @@ class SortableBookTestCase(TestCase):
         self.assertEqual(SortableBook.objects.get(pk=1).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=6).my_order, 18)
 
+    def test_bulkMoveForwardTwoPagesFromLastPage(self):
+        self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
+        post_data = {'action': ['move_to_forward_page'], 'step': 2, '_selected_action': [19, 20]}
+        self.client.post(self.bulk_update_url + '?p=2', post_data)
+        self.assertEqual(SortableBook.objects.get(pk=19).my_order, 19)
+        self.assertEqual(SortableBook.objects.get(pk=20).my_order, 20)
+
     def test_bulkMoveToSpecificPage(self):
         self.assertEqual(SortableBook.objects.get(pk=1).my_order, 1)
         self.assertEqual(SortableBook.objects.get(pk=6).my_order, 6)
@@ -188,6 +204,14 @@ class SortableBookTestCase(TestCase):
         self.client.post(self.bulk_update_url, post_data)
         self.assertEqual(SortableBook.objects.get(pk=1).my_order, 17)
         self.assertEqual(SortableBook.objects.get(pk=6).my_order, 18)
+
+    def test_bulkMoveToSpecificInvalidPage(self):
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 1)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 6)
+        post_data = {'action': ['move_to_exact_page'], 'page': 10, '_selected_action': [1, 6]}
+        self.client.post(self.bulk_update_url, post_data)
+        self.assertEqual(SortableBook.objects.get(pk=1).my_order, 1)
+        self.assertEqual(SortableBook.objects.get(pk=6).my_order, 6)
 
     def testFilledBookShelf(self):
         self.assertEqual(SortableBook.objects.count(), 20,

--- a/example/testapp/urls.py
+++ b/example/testapp/urls.py
@@ -1,8 +1,8 @@
 # -*- coding: utf-8 -*-
-from django.conf.urls import patterns, include
+from django.conf.urls import url, include
 from django.contrib import admin
 admin.autodiscover()
 
-urlpatterns = patterns('',
-    (r'^admin/', include(admin.site.urls)),
-)
+urlpatterns = [
+    url(r'^admin/', include(admin.site.urls)),
+]


### PR DESCRIPTION
Hi, when I played around with your application a little bit more I found that there are two bugs in list-sortable.js:

- when the first item was moved to the second position, moving it back without refreshing made no change (it was moved from second position again to the second position)
- when ordering was reversed moving an item one position down did nothing (check for item being dropped to its original position did not account for ordering)

So while I know next to nothing about JS :smile: I changed drag & drop handling so it should work properly now.

Also I made some changes adding django 1.9 support while hopefully not breaking anything.