### PR TITLE
Specify encoding of README to avoid UnicodeDecodeError

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,9 @@ from adminsortable2 import __version__
 try:
     from pypandoc import convert
 except ImportError:
+    import io
     def convert(filename, fmt):
-        with open(filename) as fd:
+        with io.open(filename, encoding='utf-8') as fd:
             return fd.read()
 
 DESCRIPTION = 'Generic drag-and-drop sorting for the List, the Stacked- and the Tabular-Inlines Views in the Django Admin'


### PR DESCRIPTION
This error can be seen with Python 3.4 on Linux when LANG isn't set:

```
Traceback (most recent call last):
  File "setup.py", line 34, in <module>
    long_description=convert('README.md', 'rst'),
  File "setup.py", line 12, in convert
    return fd.read()
  File "/home/trawick/.virtualenvs/2015-12-17-2/lib/python3.4/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc5 in position 876: ordinal not in range(128)
```

(The issue was originally found when installing via pip under a Salt-controlled deployment.)

580ab67@jrief added non-ASCII characters to the README, which then required that the encoding be properly guessed.