### PR TITLE
added and option for excluding order field default behaviour

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -63,6 +63,7 @@ class SortableAdminMixin(SortableAdminBase):
     enable_sorting = False
     action_form = MovePageActionForm
     change_list_template = 'adminsortable2/change_list.html'
+    exclude_default_order_field = True
 
     def __init__(self, model, admin_site):
         try:
@@ -75,10 +76,11 @@ class SortableAdminMixin(SortableAdminBase):
         except (AttributeError, IndexError):
             raise ImproperlyConfigured('Model {0}.{1} requires a list or tuple "ordering" in its Meta class'.format(model.__module__, model.__name__))
         super(SortableAdminMixin, self).__init__(model, admin_site)
-        if not isinstance(self.exclude, (list, tuple)):
-            self.exclude = [self.default_order_field]
-        elif not self.exclude or self.default_order_field != self.exclude[0]:
-            self.exclude = [self.default_order_field] + self.exclude
+        if self.exclude_default_order_field:
+            if not isinstance(self.exclude, (list, tuple)):
+                self.exclude = [self.default_order_field]
+            elif not self.exclude or self.default_order_field != self.exclude[0]:
+                self.exclude = [self.default_order_field] + self.exclude
         if not self.list_display_links:
             self.list_display_links = (self.list_display[0],)
         self._add_reorder_method()

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -98,6 +98,20 @@ That's it! The list view of the model admin interface now adds a column with a s
 By clicking on that area, the user can move that row up or down. If he wants to move it to another
 page, he can do that as a bulk operation, using the admin actions.
 
+``SortableAdminMixin`` by default, excludes the field specified in first item
+of ordering option (we call it default_order_field). This behaviour can be
+configured by a property of ``SortableAdminMixin``.
+
+.. code:: python
+
+	from django.contrib import admin
+	from adminsortable2.admin import SortableAdminMixin
+	from models import MyModel
+	
+	class MyModelAdmin(SortableAdminMixin, admin.ModelAdmin):
+        exclude_default_order_field = False
+	admin.site.register(MyModel, MyModelAdmin)
+
 
 Make a stacked or tabular inline view sortable
 ==============================================


### PR DESCRIPTION
one of my clients insists that they want the default ordering field visible and editable on detail view. This is the solution i came with.