### PR TITLE
Make change list template extendable

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -40,7 +40,18 @@ class SortableAdminMixin(SortableAdminBase):
     BACK, FORWARD, FIRST, LAST, EXACT = range(5)
     enable_sorting = False
     action_form = MovePageActionForm
-    change_list_template = 'adminsortable2/change_list.html'
+
+    @property
+    def change_list_template(self):
+        opts = self.model._meta
+        app_label = opts.app_label
+        return [
+            'adminsortable2/%s/%s/change_list.html' % (
+                app_label, opts.model_name
+            ),
+            'adminsortable2/%s/change_list.html' % app_label,
+            'adminsortable2/change_list.html'
+        ]
 
     def __init__(self, model, admin_site):
         try:

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -100,6 +100,25 @@ By clicking on that area, the user can move that row up or down. If he wants to 
 page, he can do that as a bulk operation, using the admin actions.
 
 
+Overriding change list page
+...........................
+
+To add for example a custom tool to the change list view, copy ``contrib/admin/templates/admin/change_list.html``
+to either ``templates/admin/my_app/`` or ``templates/admin/my_app/page/`` directory of your project and make sure
+you are extending from the right template:
+
+.. code:: html
+
+    {% extends "adminsortable2/change_list.html" %}
+
+    {% block object-tools-items %}
+        {{ block.super }}
+        <li>
+            <a href="mylink/">My Link</a>
+        </li>
+    {% endblock %}
+
+
 Make a stacked or tabular inline view sortable
 ==============================================
 


### PR DESCRIPTION
Hi Jacob,

I noticed that ony of my usual ways of adding custom buttons didn't work.
I would like to add my own change_list.html template at the app level and
extend original one. Django by default lets you do it. I made a quick fix
to imitate Django's functionality (+docs update).
https://docs.djangoproject.com/en/1.8/ref/contrib/admin/#overriding-vs-replacing-an-admin-template

Unless I missed something obvious this should make ours lives easier :)
but I will gladly address any comments you will have.