### PR TITLE
Reorder management command fixed

### DIFF
--- a/adminsortable2/management/commands/reorder.py
+++ b/adminsortable2/management/commands/reorder.py
@@ -7,8 +7,11 @@ class Command(BaseCommand):
     args = '<model model ...>'
     help = 'Restore the primary ordering fields of a model containing a special ordering field'
 
+    def add_arguments(self, parser):
+        parser.add_argument('models', nargs='+', type=str)
+
     def handle(self, *args, **options):
-        for modelname in args:
+        for modelname in options['models']:
             try:
                 Model = import_string(modelname)
             except ImportError:


### PR DESCRIPTION
When integrating this module into my django project the reorder command wouldn't work as indicated in the docs.  From the terminal I would run the following command:
<img width="493" alt="screen shot 2016-08-20 at 20 40 35" src="https://cloud.githubusercontent.com/assets/17380181/17833488/7664c914-6716-11e6-96b2-def6538bf06a.png">
This throws the unrecognised arguments error as shown.

Following my fix the code now runs correctly as shown here:
<img width="489" alt="screen shot 2016-08-20 at 20 43 03" src="https://cloud.githubusercontent.com/assets/17380181/17833499/c71b2f2e-6716-11e6-9410-a7f02ffae142.png">

I hope this helps and if you have any questions please feel free to ask.
Thanks for the great piece of software!