### PR TITLE
Added support for parler TranslatableInlineModelAdmin subclasses

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 import json
+import warnings
 from types import MethodType
 from django import forms
 from django.utils.translation import ugettext_lazy as _
@@ -17,7 +18,6 @@ from django.core.serializers.json import DjangoJSONEncoder
 from django.contrib import admin
 
 __all__ = ['SortableAdminMixin', 'SortableInlineAdminMixin']
-
 
 def _get_default_ordering(model):
     try:
@@ -377,8 +377,8 @@ class SortableInlineAdminMixin(SortableAdminBase):
                 from parler.admin import TranslatableInlineModelAdmin, TranslatableStackedInline, TranslatableTabularInline
                 if isinstance(self, TranslatableInlineModelAdmin):
                     if self.inline_tabs:
-                        print("Warning: adminsortable2 is incompatible with parler inline_tabs")
-                        return super().template
+                        warnings.warn('adminsortable2 is currently incompatible with parler inline_tabs')
+                        return super(SortableInlineAdminMixin, self).template
                     elif isinstance(self, TranslatableStackedInline):
                         return 'adminsortable2/stacked.html'
                     elif isinstance(self, TranslatableTabularInline):

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -383,6 +383,6 @@ class SortableInlineAdminMixin(SortableAdminBase):
                         return 'adminsortable2/stacked.html'
                     elif isinstance(self, TranslatableTabularInline):
                         return 'adminsortable2/tabular.html'
-                    raise ImportError
+                raise ImportError
             except ImportError:
                 raise ImproperlyConfigured('Class {0}.{1} must also derive from admin.TabularInline/admin.StackedInline/parler.admin.TranslatableInlineModelAdmin'.format(self.__module__, self.__class__))

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -370,6 +370,19 @@ class SortableInlineAdminMixin(SortableAdminBase):
     def template(self):
         if isinstance(self, admin.StackedInline):
             return 'adminsortable2/stacked.html'
-        if isinstance(self, admin.TabularInline):
+        elif isinstance(self, admin.TabularInline):
             return 'adminsortable2/tabular.html'
-        raise ImproperlyConfigured('Class {0}.{1} must also derive from admin.TabularInline or admin.StackedInline'.format(self.__module__, self.__class__))
+        else:
+            try:
+                from parler.admin import TranslatableInlineModelAdmin, TranslatableStackedInline, TranslatableTabularInline
+                if isinstance(self, TranslatableInlineModelAdmin):
+                    if self.inline_tabs:
+                        print("Warning: adminsortable2 is incompatible with parler inline_tabs")
+                        return super().template
+                    elif isinstance(self, TranslatableStackedInline):
+                        return 'adminsortable2/stacked.html'
+                    elif isinstance(self, TranslatableTabularInline):
+                        return 'adminsortable2/tabular.html'
+                    raise ImportError
+            except ImportError:
+                raise ImproperlyConfigured('Class {0}.{1} must also derive from admin.TabularInline/admin.StackedInline/parler.admin.TranslatableInlineModelAdmin'.format(self.__module__, self.__class__))

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -19,6 +19,7 @@ from django.contrib import admin
 
 __all__ = ['SortableAdminMixin', 'SortableInlineAdminMixin']
 
+
 def _get_default_ordering(model):
     try:
         if model._meta.ordering[0].startswith('-'):


### PR DESCRIPTION
Do you think these changes are robust enough?
I've only tested TranslatableTabularInline
