### PR TITLE
Add support for Grappelli

### DIFF
--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -101,7 +101,7 @@ jQuery(function($) {
 
 	$step_field.attr('min', 1);
 
-	$('#changelist-form').find('select[name="action"]').change(function() {
+	function display_fields() {
 		if (['move_to_back_page', 'move_to_forward_page'].indexOf($(this).val()) != -1) {
 			if ($(this).val() === 'move_to_forward_page') {
 				$step_field.attr('max', window.admin_sortable2.total_pages - window.admin_sortable2.current_page);
@@ -117,5 +117,12 @@ jQuery(function($) {
 		} else {
 			$page_field.hide();
 		}
-	});
+	}
+
+	var $grp_form = $('#grp-changelist-form'); // Grappelli support
+	if ($grp_form) {
+		$grp_form.attr('novalidate', 'novalidate');
+	}
+	var $form = $('#changelist-form') || $grp_form;
+	$form.find('select[name="action"]').change(display_fields);
 });


### PR DESCRIPTION
This PR closes #113.

I found 2 issues:

1) With Grappelli, the `changelist-form` changes to `grp-changelist-form`, so the js selector needs a update. Since I didn't found a common selector (both are by ID), I gave a name to the annonymous function and registered to both selectors.

2) The error message came from the browser trying to display the HTML5 validation of the field `changelist-form-page`, but cannot since it's hidden. The default Django template contains a novalidate attr on form, Grappelli doesn't. Since there's no other input field for the action form, I added `novalidate` to Grappelli.