### PR TITLE
pre/post save signals

### DIFF
--- a/example/testapp/tests/test_sortable.py
+++ b/example/testapp/tests/test_sortable.py
@@ -4,6 +4,7 @@ import json
 import django
 from django.contrib.auth.models import User
 from django.core.urlresolvers import reverse
+from django.db.models.signals import post_save
 from django.test import TestCase
 from django.test.client import Client
 
@@ -210,3 +211,15 @@ class SortableBookTestCase(TestCase):
         self.assertEqual(SortableBook.objects.count(), 29,
                          'Check fixtures/data.json: Book shelf shall have 29 items')
         self.assertUniqueOrderValues()
+
+    def test_post_save_is_sent_after_reorder(self):
+        updated_instances = []
+        def listener(sender, instance, **kwargs):
+            updated_instances.append(instance.pk)
+        in_data = {'startorder': 7, 'endorder': 2}  # from 12345667 to 1273456
+        post_save.connect(listener)
+        response = self.client.post(self.ajax_update_url, in_data, **self.http_headers)
+        post_save.disconnect(listener)
+        self.assertEqual(len(updated_instances), 5)
+        self.assertEqual(updated_instances, [7, 3, 4, 5, 6])  # signals are sent in final order
+        


### PR DESCRIPTION
When a drag'n drop reorder is done, `pre_save` and `post_save` signals are not sent except for the draggged'n dropped instance.

Some apps require to know when instance are saved: django-haystack for exemple when using the `RealtimeSignalProcessor`.

This PR manually send those signals before and after the reordering.

Tests included.