### PR TITLE
Issue #132: better call of pre_save signal

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -245,7 +245,8 @@ class SortableAdminMixin(SortableAdminBase):
                     update_fields=[self.default_order_field],
                     raw=False,
                     using=None or router.db_for_write(
-                        self.__class__, instance=self),
+                        self.model,
+                        instance=instance),
                 )
             # using qs.update avoid multi [pre|post]_save signal on obj.save()
             obj_qs.update(**{self.default_order_field: self.get_max_order(request, obj) + 1})


### PR DESCRIPTION
As mentionned in Django-admin-sortable issue #132 and in [django-cleanup issue #34](https://github.com/un1t/django-cleanup/issues/34), regarding Django doc into the [Model pre-save signal](https://docs.djangoproject.com/en/dev/ref/signals/#pre-save) and the ['Model' Signal definition](https://github.com/django/django/blob/d2a26c1a90e837777dabdf3d67ceec4d2a70fb86/django/db/models/signals.py#L46).

here's a simple proposition...


