### PR TITLE
Send post_save signal with all the parameters required by its annotation

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -253,7 +253,14 @@ class SortableAdminMixin(SortableAdminBase):
             move_qs.update(**move_update)
             obj_qs.update(**{self.default_order_field: finalorder})
             for instance in move_qs:
-                post_save.send(self.model, instance=instance, update_fields=[self.default_order_field])
+                post_save.send(
+                    self.model,
+                    instance=instance,
+                    update_fields=[self.default_order_field],
+                    raw=False,
+                    using=router.db_for_write(self.model, instance=instance),
+                    created=False
+                )
         query_set = self.model.objects.filter(**move_filter).order_by(self.default_order_field).values_list('pk', self.default_order_field)
         return [dict(pk=pk, order=order) for pk, order in query_set]
 


### PR DESCRIPTION
Hi, thanks for the great app!

Some time ago there was a pull request that added additional parameters to the pre_save signal, because of compatibility issues with django-cleanup. As it turns out, the lack of parameters for the post_save signal is also breaking some apps (django-reversion in my case). So, following the example of the previous contributor, I added the additional parameters to the post_save method as well. 

Please, see if my changes can be merged in, when you have a chance.