### PR TITLE
Use current admin site name instead of 'admin'

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -352,7 +352,8 @@ class SortableAdminMixin(SortableAdminBase):
         """
         Returns a callback URL used for updating items via AJAX drag-n-drop
         """
-        return reverse('admin:' + self._get_update_url_name())
+        return reverse('%s:%s' % (
+            self.admin_site.name, self._get_update_url_name()))
 
 
 class PolymorphicSortableAdminMixin(SortableAdminMixin):


### PR DESCRIPTION
This commit allows using this library in multiple admin sites