### PR TITLE
Update django.po

### DIFF
--- a/adminsortable2/locale/it/LC_MESSAGES/django.po
+++ b/adminsortable2/locale/it/LC_MESSAGES/django.po
@@ -58,7 +58,7 @@ msgstr "Rimuovi"
 #: templates/adminsortable/tabular-1.6.html:76
 #, python-format
 msgid "Add another %(verbose_name)s"
-msgstr "Aggiungi un altro $(verbose_name)"
+msgstr "Aggiungi un altro %(verbose_name)s"
 
 #: templates/adminsortable/tabular-1.5.html:17
 #: templates/adminsortable/tabular-1.6.html:17


### PR DESCRIPTION
Italian version has wrong msgstr translation of verbose_name. Fixed translation.