### PR TITLE
Allow sortable field not in the first column for the SortableAdminMixin

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -106,7 +106,9 @@ class SortableAdminMixin(SortableAdminBase):
         if not self.list_display_links:
             self.list_display_links = (self.list_display[0],)
         self._add_reorder_method()
-        self.list_display = ['_reorder'] + list(self.list_display)
+        self.list_display = [e.replace(self.default_order_field, '_reorder') for e in self.list_display]
+        if '_reorder' not in self.list_display:
+            self.list_display = ['_reorder'] + list(self.list_display)
 
     def _get_update_url_name(self):
         return '%s_%s_sortable_update' % (self.model._meta.app_label, self.model._meta.model_name)

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -4,6 +4,8 @@ from __future__ import unicode_literals
 import os
 import json
 
+from re import sub
+
 from types import MethodType
 
 from django import forms
@@ -106,7 +108,7 @@ class SortableAdminMixin(SortableAdminBase):
         if not self.list_display_links:
             self.list_display_links = (self.list_display[0],)
         self._add_reorder_method()
-        self.list_display = [e.replace(self.default_order_field, '_reorder') for e in self.list_display]
+        self.list_display = [sub(r'^%s$' % self.default_order_field, '_reorder', e) for e in self.list_display]
         if '_reorder' not in self.list_display:
             self.list_display = ['_reorder'] + list(self.list_display)
 


### PR DESCRIPTION
PR for issue #155 

Include implicit `_reorder` field in the position the order field gets referenced with `display_list`. The default position remains the first column, in the case the order fields doesn't get referenced in `display_list`.

For instance, in order to allow the order field on the fifth column, the code should be:
```python
@admin.register(GameMedia)
class GameMediaAdmin(SortableAdminMixin, admin.ModelAdmin):
    list_display = ['image_tag', 'name', 'description', 
        'platform', 'position', 'enabled']
    fields = ('image_tag', 'name', 'description', 'platform', 
        'source_url', 'icon_url', 'enabled')
    readonly_fields = ('image_tag',)
    ordering = ('position',)
```
where `position` is the reordering field in this case.