### PR TITLE
Allow reorder command to work with application names

### DIFF
--- a/adminsortable2/management/commands/reorder.py
+++ b/adminsortable2/management/commands/reorder.py
@@ -1,8 +1,10 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
-
+import inspect
 from django.apps import apps
 from django.core.management.base import BaseCommand, CommandError
+from django.contrib.admin import site
+from ...admin import SortableAdminMixin
 
 
 class Command(BaseCommand):
@@ -10,21 +12,43 @@ class Command(BaseCommand):
     help = 'Restore the primary ordering fields of a model containing a special ordering field'
 
     def add_arguments(self, parser):
-        parser.add_argument('models', nargs='+', type=str)
+        parser.add_argument('models or apps', nargs='+', type=str)
 
     def handle(self, *args, **options):
-        for modelname in options['models']:
-            try:
-                app_label, model_name = modelname.rsplit('.', 1)
-                Model = apps.get_model(app_label, model_name)
-            except ImportError:
-                raise CommandError('Unable to load model "%s"' % modelname)
-            if not hasattr(Model._meta, 'ordering') or len(Model._meta.ordering) == 0:
-                raise CommandError('Model "{0}" does not define field "ordering" in its Meta class'.format(modelname))
-            orderfield = Model._meta.ordering[0]
+        def set_order_model_objects(model):
+            """Set order to model's all objects"""
+            if not hasattr(model._meta, 'ordering') or len(model._meta.ordering) == 0:
+                raise CommandError(
+                    'Model "{0}" does not define field "ordering" in its Meta class'.format(
+                        model_or_app_name))
+            orderfield = model._meta.ordering[0]
             if orderfield[0] == '-':
                 orderfield = orderfield[1:]
-            for order, obj in enumerate(Model.objects.iterator(), start=1):
+            for order, obj in enumerate(model.objects.iterator(), start=1):
                 setattr(obj, orderfield, order)
                 obj.save()
-            self.stdout.write('Successfully reordered model "{0}"'.format(modelname))
+            self.stdout.write('Successfully reordered model "{0}"'.format(model))
+
+        for model_or_app_name in options['models or apps']:
+            try:
+                app_label, model_name = model_or_app_name.rsplit('.', 1)
+                model = apps.get_model(app_label, model_name)
+            # if the attempt to split fails, the app with that name gets the sortable models
+            except ValueError:
+                try:
+                    # Check the app is exist
+                    apps.get_app_config(model_or_app_name)
+                    # Import registered Models and ModelAdmins in _registry of admin app.
+                    for model, model_admin in site._registry.items():
+                        # Check current model is current app's model
+                        if str(model_admin).startswith('%s.' % model_or_app_name):
+                            # If ModelAdmin inherits SortableAdminMixin,
+                            # use the Model to execute the set_order_model_objects () method.
+                            if SortableAdminMixin in inspect.getmro(model_admin.__class__):
+                                set_order_model_objects(model)
+                except:
+                    raise CommandError('Unable to load app "%s"' % model_or_app_name)
+            except ImportError:
+                raise CommandError('Unable to load model "%s"' % model_or_app_name)
+            else:
+                set_order_model_objects(model)


### PR DESCRIPTION
Hello. I am using the library and it was cumbersome to specify the models with the reorder command, so I modified the command to work with the application name.
If you run the reorder command with the application name will only work on models that inherit SortableAdminMixin and registerd with Django admin. 

1. The process of registering orders in one model has been separated by the set_order_model_objects () method.
2. Import registered Models and ModelAdmins in _registry of admin app.
3. If ModelAdmin inherits SortableAdminMixin, use the Model to execute the set_order_model_objects () method.

```shell
# ex) application name is 'prduct'
./manage.py reorder product
Successfully reordered model "<class 'product.models.product_category.ProductCategoryTop'>"
Successfully reordered model "<class 'product.models.product_category.ProductCategoryMiddle'>"
```