### PR TITLE
Fixes #162 - removal of admin actions breaks admin-sortable2

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -171,7 +171,7 @@ class SortableAdminMixin(SortableAdminBase):
         def func(this, item):
             html = ''
             if this.enable_sorting:
-                html = '<div class="drag" order="{0}">&nbsp;</div>'.format(getattr(item, this.default_order_field))
+                html = '<div class="drag js-reorder-{1}" order="{0}">&nbsp;</div>'.format(getattr(item, this.default_order_field), item.pk)
             return html
 
         setattr(func, 'allow_tags', True)

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -45,7 +45,7 @@ jQuery(function($) {
 			$result_list.find('tbody tr').each(function(index) {
 				$(this).removeClass('row1 row2').addClass(index % 2 ? 'row2' : 'row1');
 			});
-			endindex = dragged_rows.item.index()
+			endindex = dragged_rows.item.index();
 
 			if (startindex == endindex) return;
 			else if (endindex == 0) {
@@ -69,7 +69,7 @@ jQuery(function($) {
 				},
 				success: function(moved_items) {
 					$.each(moved_items, function(index, item) {
-						$result_list.find('tbody tr input.action-select[value=' + item.pk + ']').parents('tr').each(function() {
+						$result_list.find('tbody tr .js-reorder-' + item.pk).parents('tr').each(function() {
 							$(this).find('div.drag').attr('order', item.order);
 						});
 					});


### PR DESCRIPTION
The dependency on admin actions was simply a means of obtaining the item ID from the extra checkbox widget that exists only when there are admin actions. It was trivial to instead, render a custom class on our custom sort widget that provides the same ID and thus removing a dependency for an unrelated feature.