### PR TITLE
Update admin.py

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -413,7 +413,10 @@ class SortableInlineAdminMixin(SortableAdminBase):
         fields = super(SortableInlineAdminMixin, self).get_fields(request, obj)
         default_order_directions, default_order_field = _get_default_ordering(self.model, self)
 
-        if fields[0] == default_order_field:
+        if not (default_order_field in fields):
+            # If the order field is not in the field list, add it
+            fields.append(default_order_field)
+        elif fields[0] == default_order_field:
             """
             Remove the order field and add it again immediately to ensure it is not on first position.
             This ensures that django's template for tabular inline renders the first column with colspan="2":


### PR DESCRIPTION
When an inline does not have any fields listed, everything works fine. But when fields does exist and does not include the order field, the order field is not added at all, so no changes ever happen to the ordering when saved. This fix should remedy that, although it's untested. Either that, or a note should be made to always include the order field in the field list, which is what I will be doing until this is fixed.