### PR TITLE
fix #137 proposition to allow standard collapsible tabular inline.

### DIFF
--- a/adminsortable2/templates/adminsortable2/tabular.html
+++ b/adminsortable2/templates/adminsortable2/tabular.html
@@ -2,7 +2,7 @@
 <div class="inline-group sortable" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}
-<fieldset class="module">
+<fieldset class="module {{ inline_admin_formset.classes }}">
    <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
    {{ inline_admin_formset.formset.non_form_errors }}
    <table>


### PR DESCRIPTION
Following your message, and lately, I propose this little fix. Tested with Django 1.10.8 + 1.11. 

Should be compatible with other version though.

Regards.
Marc