### PR TITLE
FIX: Removes inline scripts for CSP compatibility

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -437,7 +437,11 @@ class SortableInlineAdminMixin(SortableAdminBase):
 
     @property
     def media(self):
-        return super(SortableInlineAdminMixin, self).media + widgets.Media(js=('adminsortable2/js/inline-sortable.js',))
+        shared = super(SortableInlineAdminMixin, self).media + widgets.Media(js=('adminsortable2/js/inline-sortable.js',))
+        if isinstance(self, admin.StackedInline):
+            return shared + widgets.Media(js=('adminsortable2/js/inline-stacked.js',))
+        if isinstance(self, admin.TabularInline):
+            return shared + widgets.Media(js=('adminsortable2/js/inline-tabular.js',))
 
     @property
     def template(self):

--- a/adminsortable2/static/adminsortable2/js/inline-stacked.js
+++ b/adminsortable2/static/adminsortable2/js/inline-stacked.js
@@ -1,0 +1,11 @@
+django.jQuery(function ($) {
+	$("script.inline-stacked-config").each(function(i, config_element) {
+		try {
+			var config = JSON.parse(config_element.text());
+			$("#"+ config["prefix"] + "-group .inline-related").stackedFormset(config);
+		}
+		catch (parse_error) {
+			console.error("Configuration for a django-adminsortable2 inline-stacked form is invalid.");
+		}
+	});
+});

--- a/adminsortable2/static/adminsortable2/js/inline-tabular.js
+++ b/adminsortable2/static/adminsortable2/js/inline-tabular.js
@@ -1,0 +1,11 @@
+django.jQuery(function ($) {
+	$("script.inline-tabular-config").each(function(i, config_element) {
+		try {
+			var config = JSON.parse(config_element.textContent);
+			$("#"+ config["prefix"] + "-group .tabular.inline-related tbody tr").tabularFormset(config);
+		}
+		catch (parse_error) {
+			console.error("Configuration for a django-adminsortable2 inline-tabular form is invalid.");
+		}
+	});
+});

--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -16,8 +16,13 @@ jQuery(function($) {
 	};
 	var ordering = getQueryParams()['o'];
 
-	if (window.admin_sortable2 === undefined)
-		return;  // global variables not initialized by change_list.html
+	try {
+		var config = JSON.parse($("#admin_sortable2_config").text());
+	}
+	catch (parse_error) {
+		return;  // configuration not initialized by change_list.html
+	}
+
 	if (ordering === undefined) {
 		ordering = '1';
 	}
@@ -59,7 +64,7 @@ jQuery(function($) {
 			startorder = $(dragged_rows.item.context).find('div.drag').attr('order');
 
 			$.ajax({
-				url: window.admin_sortable2.update_url,
+				url: config.update_url,
 				type: 'POST',
 				data: {
 					o: ordering,
@@ -87,17 +92,22 @@ jQuery(function($) {
 jQuery(function($) {
 	var $step_field = $('#changelist-form-step');
 	var $page_field = $('#changelist-form-page');
-	if (window.admin_sortable2 === undefined)
-		return;  // global variables not initialized by change_list.html
 
-	if (window.admin_sortable2.current_page === window.admin_sortable2.total_pages) {
-		$page_field.attr('max', window.admin_sortable2.total_pages - 1);
-		$page_field.val(window.admin_sortable2.current_page - 1);
-	} else {
-		$page_field.attr('max', window.admin_sortable2.total_pages);
-		$page_field.val(window.admin_sortable2.current_page + 1)
+	try {
+		var config = JSON.parse($("#admin_sortable2_config").text());
 	}
-	if (window.admin_sortable2.current_page === 1) {
+	catch (parse_error) {
+		return;  // configuration not initialized by change_list.html
+	}
+
+	if (config.current_page === config.total_pages) {
+		$page_field.attr('max', config.total_pages - 1);
+		$page_field.val(config.current_page - 1);
+	} else {
+		$page_field.attr('max', config.total_pages);
+		$page_field.val(config.current_page + 1)
+	}
+	if (config.current_page === 1) {
 		$page_field.attr('min', 2);
 	} else {
 		$page_field.attr('min', 1);
@@ -108,9 +118,9 @@ jQuery(function($) {
 	function display_fields() {
 		if (['move_to_back_page', 'move_to_forward_page'].indexOf($(this).val()) != -1) {
 			if ($(this).val() === 'move_to_forward_page') {
-				$step_field.attr('max', window.admin_sortable2.total_pages - window.admin_sortable2.current_page);
+				$step_field.attr('max', config.total_pages - config.current_page);
 			} else {
-				$step_field.attr('max', window.admin_sortable2.current_page - 1);
+				$step_field.attr('max', config.current_page - 1);
 			}
 			$step_field.show();
 		} else {

--- a/adminsortable2/templates/adminsortable2/change_list.html
+++ b/adminsortable2/templates/adminsortable2/change_list.html
@@ -2,11 +2,11 @@
 
 {% block extrahead %}
 	{{ block.super }}
-	<script type="text/javascript">
-		window.admin_sortable2 = {
-			update_url: '{{ sortable_update_url }}',
-			current_page: {{ cl.page_num | add:'1' }},
-			total_pages: {{ cl.paginator.num_pages }}
-		};
+	<script type="application/json" id="admin_sortable2_config">
+		{
+			"update_url": "{{ sortable_update_url }}",
+			"current_page": {{ cl.page_num | add:'1' }},
+			"total_pages": {{ cl.paginator.num_pages }}
+		}
 	</script>
 {% endblock %}

--- a/adminsortable2/templates/adminsortable2/stacked.html
+++ b/adminsortable2/templates/adminsortable2/stacked.html
@@ -19,13 +19,11 @@
 </div>{% endfor %}
 </div>
 
-<script type="text/javascript">
-(function($) {
-  $("#{{ inline_admin_formset.formset.prefix|escapejs }}-group .inline-related").stackedFormset({
-    prefix: "{{ inline_admin_formset.formset.prefix|escapejs }}",
-    deleteText: "{% filter escapejs %}{% trans "Remove" %}{% endfilter %}",
-    addText: "{% filter escapejs %}{% blocktrans with verbose_name=inline_admin_formset.opts.verbose_name|capfirst %}Add another {{ verbose_name }}{% endblocktrans %}{% endfilter %}"
-  });
-})(django.jQuery);
+<script type="application/json" class="inline-stacked-config">
+{
+  "prefix": "{{ inline_admin_formset.formset.prefix|escapejs }}",
+  "deleteText": "{% filter escapejs %}{% trans "Remove" %}{% endfilter %}",
+  "addText": "{% filter escapejs %}{% blocktrans with verbose_name=inline_admin_formset.opts.verbose_name|capfirst %}Add another {{ verbose_name }}{% endblocktrans %}{% endfilter %}"
+}
 </script>
 <div class="default_order_field" default_order_field="{{ inline_admin_formset.formset.default_order_field }}"></div>

--- a/adminsortable2/templates/adminsortable2/tabular.html
+++ b/adminsortable2/templates/adminsortable2/tabular.html
@@ -72,14 +72,11 @@
   </div>
 </div>
 
-<script type="text/javascript">
-
-(function($) {
-  $("#{{ inline_admin_formset.formset.prefix|escapejs }}-group .tabular.inline-related tbody tr").tabularFormset({
-    prefix: "{{ inline_admin_formset.formset.prefix|escapejs }}",
-    addText: "{% filter escapejs %}{% blocktrans with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}{% endfilter %}",
-    deleteText: "{% filter escapejs %}{% trans 'Remove' %}{% endfilter %}"
-  });
-})(django.jQuery);
+<script type="application/json" class="inline-tabular-config">
+{
+  "prefix": "{{ inline_admin_formset.formset.prefix|escapejs }}",
+  "addText": "{% filter escapejs %}{% blocktrans with inline_admin_formset.opts.verbose_name|capfirst as verbose_name %}Add another {{ verbose_name }}{% endblocktrans %}{% endfilter %}",
+  "deleteText": "{% filter escapejs %}{% trans 'Remove' %}{% endfilter %}"
+}
 </script>
 <div class="default_order_field" default_order_field="{{ inline_admin_formset.formset.default_order_field }}"></div>


### PR DESCRIPTION
In order to enforce an effective CSP, sites must disallow the use of inline scripts, as they are a common exploit vector for attacks. Unfortunately, django-admin-sortable2 uses them in three places to pass configuration data to the front-end. This causes it to break when such a CSP is enforced.

This PR fixes the issue by splitting the inline scripts into two parts. The configuration data is converted into JSON structures which are left in the templates and the logic is moved to external scripts. The commit message has a more detailed list of the changes.