### PR TITLE
Never rename a list_display member, fix for #166

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -4,8 +4,6 @@ from __future__ import unicode_literals
 import os
 import json
 
-from re import sub
-
 from types import MethodType
 
 from django import forms
@@ -98,10 +96,11 @@ class SortableAdminMixin(SortableAdminBase):
         if not self.list_display_links:
             self.list_display_links = (self.list_display[0],)
         self._add_reorder_method()
-        self.list_display = [sub(r'^{}$'.format(self.default_order_field), '_reorder', e) if isinstance(e, str) else e
-                             for e in self.list_display]
-        if '_reorder' not in self.list_display:
-            self.list_display = ['_reorder'] + list(self.list_display)
+        self.list_display = list(self.list_display)
+        try:
+            self.list_display.insert(self.list_display.index(self.default_order_field), '_reorder')
+        except ValueError:
+            self.list_display.insert(0, '_reorder')
 
     def _get_update_url_name(self):
         return '%s_%s_sortable_update' % (self.model._meta.app_label, self.model._meta.model_name)

--- a/example/testapp/admin.py
+++ b/example/testapp/admin.py
@@ -29,3 +29,9 @@ class SortableBookAdmin(SortableAdminMixin, admin.ModelAdmin):
 @admin.register(models.Author)
 class AuthorAdmin(admin.ModelAdmin):
     list_display = ('name',)
+
+
+@admin.register(models.Notes)
+class NoteAdmin(SortableAdminMixin, admin.ModelAdmin):
+    list_display = ('note',)
+    ordering = ('note',)


### PR DESCRIPTION
Add failing check test on Django 1.11.

There is even no need for a real test, the admin registration fails if you combine a `SortableAdminMixin` with `list_display` and ordering and that `list_display_links` has the first / the replaced element of `list_display`.

This simple setup causes the Django check 
```<class 'testapp.admin.NoteAdmin'>: (admin.E111) The value of 'list_display_links[0]' refers to 'note', which is not defined in 'list_display'.```

The bug was introduced with the MR #156 

Fixing proposition is in a separate commit, to prove the failure as shown in #166 