### PR TITLE
Allow combining admin mixins by storing original change_list_template

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -81,7 +81,7 @@ class SortableAdminMixin(SortableAdminBase):
     action_form = MovePageActionForm
 
     @property
-    def change_list_template(self):
+    def sortable_change_list_template(self):
         opts = self.model._meta
         app_label = opts.app_label
         return [
@@ -123,6 +123,13 @@ class SortableAdminMixin(SortableAdminBase):
         rev_field = '-' + self.default_order_field
         if self.ordering and rev_field in self.ordering:
             self.ordering = [f for f in self.ordering if f != rev_field]
+
+        # Store original change_list_template to allow usage with other mixins
+        if self.change_list_template:
+            self.original_change_list_template = self.change_list_template
+        else:
+            self.original_change_list_template = "admin/change_list.html"
+        self.change_list_template = self.sortable_change_list_template
 
     def _get_update_url_name(self):
         return '%s_%s_sortable_update' % (self.model._meta.app_label, self.model._meta.model_name)
@@ -369,6 +376,7 @@ class SortableAdminMixin(SortableAdminBase):
 
         extra_context['sortable_update_url'] = self.get_update_url(request)
         extra_context['default_order_direction'] = self.default_order_direction
+        extra_context['original_change_list_template'] = self.original_change_list_template
         return super(SortableAdminMixin, self).changelist_view(request, extra_context)
 
     def get_update_url(self, request):

--- a/adminsortable2/templates/adminsortable2/change_list.html
+++ b/adminsortable2/templates/adminsortable2/change_list.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends original_change_list_template %}
 
 {% block extrahead %}
 	{{ block.super }}

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,10 @@
 Release history
 ===============
 
+0.6.20
+------
+* Fix `SortableAdminMixin` to work in combination with other mixins like that from `django-import-export`.
+
 0.6.19
 ------
 * Fix #183: Use ``mark_safe`` for reorder ``div``.


### PR DESCRIPTION
If I want to combine `SortableAdminMixin` with other admin mixins like that from `django-import-export`, it doesn't work. It is cased by `change_list_template` property, which original value needs to be stored and used for `extends` in the template.