### PR TITLE
Add the docs explaining how to make your migration reversible

### DIFF
--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -273,6 +273,8 @@ then apply the changes to the database using:
 
 .. note:: If you omit to prepopulate the ordering field with unique values, after adding this field
 		to an existing model, then attempting to reorder field manually will fail.
+		If you want to make your migration reversible just add the 
+		reverse_code=migrations.RunPython.noop as the second param.
 
 
 Note on unique indices on the position field


### PR DESCRIPTION

I run in this situation some times, after we do the migration theres no turning back, this makes it possible. 
I think its better to maybe put on the main example but I leave that decision to you.

If you want the code is here

```
class Migration(migrations.Migration):
    operations = [
        ....
        migrations.RunPython(reorder, reverse_code=migrations.RunPython.noop),
    ]
```