### PR TITLE
fix existance check

### DIFF
--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -137,6 +137,6 @@ django.jQuery(function($) {
 	if ($grp_form) {
 		$grp_form.attr('novalidate', 'novalidate');
 	}
-	var $form = $('#changelist-form') || $grp_form;
-	$form.find('select[name="action"]').change(display_fields);
+    var $form = $('#changelist-form').length ? $('#changelist-form') : $grp_form;
+    $form.find('select[name="action"]').change(display_fields);
 });


### PR DESCRIPTION
The original check will not work since $('#changelist-form') will be recognized as true even it does not exist.