### PR TITLE
Update 'admin_static' template tag to 'static' due deprecation in Dja…

### DIFF
--- a/adminsortable2/templates/adminsortable2/stacked.html
+++ b/adminsortable2/templates/adminsortable2/stacked.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static %}
+{% load i18n admin_urls static %}
 <div class="inline-group sortable" id="{{ inline_admin_formset.formset.prefix }}-group">
   <h2>{{ inline_admin_formset.opts.verbose_name_plural|capfirst }}</h2>
 {{ inline_admin_formset.formset.management_form }}

--- a/adminsortable2/templates/adminsortable2/tabular.html
+++ b/adminsortable2/templates/adminsortable2/tabular.html
@@ -1,4 +1,4 @@
-{% load i18n admin_urls admin_static admin_modify %}
+{% load i18n admin_urls static admin_modify %}
 <div class="inline-group sortable" id="{{ inline_admin_formset.formset.prefix }}-group">
   <div class="tabular inline-related {% if forloop.last %}last-related{% endif %}">
 {{ inline_admin_formset.formset.management_form }}


### PR DESCRIPTION
…ngo 3.0

RemovedInDjango30Warning: {% load admin_static %} is deprecated in favor of {% load static %}.