### PR TITLE
Add support for Django 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
   - DJANGO="django<2.1"
   - DJANGO="django<2.2"
   - DJANGO="django<2.3"
+  - DJANGO="django<3.1"
   - DJANGO='https://github.com/django/django/archive/master.tar.gz'
 
 install:
@@ -31,10 +32,18 @@ matrix:
     - python: 2.7
       env: DJANGO="django<2.3"
     - python: 2.7
+      env: DJANGO="django<3.1"
+    - python: 2.7
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
     - python: 3.4
       env: DJANGO="django<2.3"
     - python: 3.4
+      env: DJANGO="django<3.1"
+    - python: 3.4
+      env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
+    - python: 3.5
+      env: DJANGO="django<3.1"
+    - python: 3.5
       env: DJANGO='https://github.com/django/django/archive/master.tar.gz'
   allow_failures:
      - env: DJANGO='https://github.com/django/django/archive/master.tar.gz'

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ CLASSIFIERS = [
     'Framework :: Django :: 2.0',
     'Framework :: Django :: 2.1',
     'Framework :: Django :: 2.2',
+    'Framework :: Django :: 3.0',
 ]
 
 
@@ -52,7 +53,7 @@ setup(
     platforms=['OS Independent'],
     classifiers=CLASSIFIERS,
     install_requires=[
-        'Django>=1.8,<3',
+        'Django>=1.8,<3.1',
     ],
     packages=find_packages(exclude=['example', 'docs']),
     include_package_data=True,


### PR DESCRIPTION
Everything seems to work without modification.

Local test are passing successfully.

Django 3.0 drops support for Python 3.5, which is reflected in the travis configuration.