### PR TITLE
Fixed styling for stacked inlines.

### DIFF
--- a/adminsortable2/templates/adminsortable2/includes/fieldset.html
+++ b/adminsortable2/templates/adminsortable2/includes/fieldset.html
@@ -9,7 +9,7 @@
             {% if line.fields|length_is:'1' %}{{ line.errors }}{% endif %}
             {% for field in line %}
                 {% if field.field.is_hidden %}{{ field.field }}{% else %}
-                <div{% if not line.fields|length_is:'1' %} class="field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}"{% endif %}>
+                <div{% if not line.fields|length_is:'1' %} class="fieldBox field-box{% if field.field.name %} field-{{ field.field.name }}{% endif %}{% if not field.is_readonly and field.errors %} errors{% endif %}"{% endif %}>
                     {% if not line.fields|length_is:'1' and not field.is_readonly %}{{ field.errors }}{% endif %}
                     {% if field.is_checkbox %}
                         {{ field.field }}{{ field.label_tag }}


### PR DESCRIPTION
According to the 2.1 release notes:
```
* The admin CSS class ``field-box`` is renamed to ``fieldBox`` to prevent
  conflicts with the class given to model fields named "box".
```

Since adminsortable2 currently supports Django 2.0 as well I left the original `field-box` in there as well. No stacked templates work properly again :)

If you think Django 2.0 support could be dropped, then `field-box` could be removed as well.