### PR TITLE
Handle non-numeric page numbers

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -162,7 +162,7 @@ class SortableAdminMixin(SortableAdminBase):
             try:
                 cur_page = int(request.GET.get('p', 0)) + 1
             except ValueError:
-                return actions
+                cur_page = 1
             if len(paginator.page_range) > 2 and cur_page > paginator.page_range[1]:
                 move_actions.append('move_to_first_page')
             if cur_page > paginator.page_range[0]:

--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -159,7 +159,10 @@ class SortableAdminMixin(SortableAdminBase):
         if len(paginator.page_range) > 1 and 'all' not in request.GET and self.enable_sorting:
             # add actions for moving items to other pages
             move_actions = ['move_to_exact_page']
-            cur_page = int(request.GET.get('p', 0)) + 1
+            try:
+                cur_page = int(request.GET.get('p', 0)) + 1
+            except ValueError:
+                return actions
             if len(paginator.page_range) > 2 and cur_page > paginator.page_range[1]:
                 move_actions.append('move_to_first_page')
             if cur_page > paginator.page_range[0]:


### PR DESCRIPTION
This was picked up in fuzzing tests against our site running your plugin. The code errors if a non-numeric page number is supplied. This fix means this (admittedly unlikely) eventuality is handled more elegantly.