### PR TITLE
Remove disable selection of text content on list view

### DIFF
--- a/adminsortable2/static/adminsortable2/js/list-sortable.js
+++ b/adminsortable2/static/adminsortable2/js/list-sortable.js
@@ -81,7 +81,6 @@ django.jQuery(function($) {
 			});
 		}
 	});
-	$('#result_list, tbody, tr, td, th').disableSelection();
 });
 
 // Show and hide the step input field


### PR DESCRIPTION
Copy doesn't work.

Sometimes we need to copy content from columns. 

We don't need to disable text selection for drag and drop, because we have a specific column for it. 