### PR TITLE
Fix #316: Allow combining admin mixins by storing original change_list_template

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -71,7 +71,7 @@ class SortableAdminMixin(SortableAdminBase):
     action_form = MovePageActionForm
 
     @property
-    def change_list_template(self):
+    def sortable_change_list_template(self):
         opts = self.model._meta
         app_label = opts.app_label
         return [
@@ -86,6 +86,13 @@ class SortableAdminMixin(SortableAdminBase):
         self.enable_sorting = False
         self.order_by = None
         self._add_reorder_method()
+
+        # Store original change_list_template to allow usage with other mixins
+        if self.change_list_template:
+            self.original_change_list_template = self.change_list_template
+        else:
+            self.original_change_list_template = "admin/change_list.html"
+        self.change_list_template = [str(s) for s in self.sortable_change_list_template]
 
     def get_list_display(self, request):
         list_display = list(super().get_list_display(request))
@@ -383,6 +390,7 @@ class SortableAdminMixin(SortableAdminBase):
     def changelist_view(self, request, extra_context=None):
         extra_context = extra_context or {}
         extra_context['sortable_update_url'] = self.get_update_url(request)
+        extra_context['original_change_list_template'] = self.original_change_list_template
         return super().changelist_view(request, extra_context)
 
     def get_update_url(self, request):

--- a/adminsortable2/templates/adminsortable2/change_list.html
+++ b/adminsortable2/templates/adminsortable2/change_list.html
@@ -1,4 +1,4 @@
-{% extends "admin/change_list.html" %}
+{% extends original_change_list_template %}
 
 {% block extrahead %}
 	{{ block.super }}

--- a/testapp/admin.py
+++ b/testapp/admin.py
@@ -29,6 +29,7 @@ class ChapterTabularInline(SortableInlineAdminMixin, admin.TabularInline):
 
 
 class SortableBookAdmin(SortableAdminMixin, admin.ModelAdmin):
+    change_list_template = "foo_changelist_template.html"
     list_per_page = 12
     list_display = ['title', 'author', 'my_order']
 

--- a/testapp/templates/foo_changelist_template.html
+++ b/testapp/templates/foo_changelist_template.html
@@ -1,0 +1,6 @@
+{% extends "admin/change_list.html" %}
+
+{% block extrahead %}
+   {{ block.super }}
+   <div>Foo value</div>
+{% endblock %}

--- a/testapp/test_add_sortable.py
+++ b/testapp/test_add_sortable.py
@@ -9,6 +9,19 @@ alex_martelli_id = 24
 
 
 @pytest.mark.django_db
+def test_changelist_get():
+    num_books = SortableBook3.objects.count()
+    assert SortableBook3.objects.last().my_order == num_books
+    client = Client()
+    response = client.get(reverse('admin:testapp_sortablebook_changelist'))
+    assert response.status_code == 200, "Unable to add book"
+    assert b'"update_url": "/admin/testapp/sortablebook/adminsortable2_update/"' in response.content
+    assert b'"current_page": 1,' in response.content
+    assert b'<div>Foo value</div>' in response.content  # Test, that original template is used as parent
+    assert b'<a href="/admin/">Django administration</a' in response.content  # Test that also other parts of the template remained
+
+
+@pytest.mark.django_db
 def test_add_book():
     form_data = {
         'title': "Python Cookbook",


### PR DESCRIPTION
Fix #316

The problem is caused by `django-admin-sortable2` ignoring the value of `change_list_template` property from previous mixins.
This PR stores renames the `changoe_list_template` to `sortable_change_list_template` to allow access to the original property value. Then it sets the new value in `__init__`, but uses the original value as base template for `admin/change_list.html` so that overriding of these templates is chained together.