### PR TITLE
enlarge top/down buttons of SortableTabularInline

### DIFF
--- a/adminsortable2/static/adminsortable2/css/sortable.css
+++ b/adminsortable2/static/adminsortable2/css/sortable.css
@@ -42,19 +42,11 @@ fieldset.sortable :is(.inline-related, td.original) span.sort i {
 	margin: 2.5px;
 	cursor: pointer;
 }
-fieldset.sortable .inline-related span.sort i.move-begin {
+fieldset.sortable span.sort i.move-begin {
 	border-width: 0 7.5px 7.5px 7.5px;
 	border-color: transparent transparent currentColor transparent;
 }
-fieldset.sortable .inline-related span.sort i.move-end {
+fieldset.sortable span.sort i.move-end {
 	border-width: 7.5px 7.5px 0 7.5px;
-	border-color: currentColor transparent transparent transparent;
-}
-fieldset.sortable td.original span.sort i.move-begin {
-	border-width: 0 5px 5px 5px;
-	border-color: transparent transparent currentColor transparent;
-}
-fieldset.sortable td.original span.sort i.move-end {
-	border-width: 5px 5px 0 5px;
 	border-color: currentColor transparent transparent transparent;
 }


### PR DESCRIPTION
enlarge top/down buttons of SortableTabularInline to the same size as SortableStackedInline as they were very tiny and hard to click (resolves #319)

Before:
![before](https://user-images.githubusercontent.com/15526835/183702190-915cf15a-52b3-43b3-b778-2a0392b71f97.png)

After:
![after](https://user-images.githubusercontent.com/15526835/183702194-95b70675-9146-4e36-94b7-436ce2df25a9.png)

