### PR TITLE
add jinja template engine regression test (#320)

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -96,11 +96,12 @@ class SortableAdminMixin(SortableAdminBase):
     def change_list_template(self):
         opts = self.model._meta
         app_label = opts.app_label
-        return [
+        templates = [
             Path('adminsortable2') / Path(app_label) / Path(opts.model_name) / Path('change_list.html'),
             Path('adminsortable2') / Path(app_label) / Path('change_list.html'),
             Path('adminsortable2/change_list.html'),
         ]
+        return [str(path) for path in templates]
 
     def __init__(self, model, admin_site):
         self.default_order_direction, self.default_order_field = _get_default_ordering(model, self)

--- a/testapp/requirements.txt
+++ b/testapp/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.5.0
 attrs==21.4.0
 certifi==2021.10.8
 charset-normalizer==2.0.12
+jinja2
 greenlet==1.1.2
 idna==3.3
 iniconfig==1.1.1

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -53,6 +53,18 @@ SILENCED_SYSTEM_CHECKS = ['admin.E408']
 STATIC_URL = '/static/'
 
 TEMPLATES = [{
+    'BACKEND': 'django.template.backends.jinja2.Jinja2',
+    'DIRS': [],
+    'APP_DIRS': True,
+    'OPTIONS': {
+        'context_processors': [
+            'django.template.context_processors.debug',
+            'django.template.context_processors.request',
+            'django.contrib.auth.context_processors.auth',
+            'django.contrib.messages.context_processors.messages',
+        ],
+    },
+}, {
     'BACKEND': 'django.template.backends.django.DjangoTemplates',
     'DIRS': [],
     'APP_DIRS': True,

--- a/testapp/settings.py
+++ b/testapp/settings.py
@@ -57,12 +57,7 @@ TEMPLATES = [{
     'DIRS': [],
     'APP_DIRS': True,
     'OPTIONS': {
-        'context_processors': [
-            'django.template.context_processors.debug',
-            'django.template.context_processors.request',
-            'django.contrib.auth.context_processors.auth',
-            'django.contrib.messages.context_processors.messages',
-        ],
+        'context_processors': [],
     },
 }, {
     'BACKEND': 'django.template.backends.django.DjangoTemplates',


### PR DESCRIPTION
Somehow github closed my other pr (#325) when i wanted to revert the reverted commit and add the regression test, so here is the new one.
note that just adding an additional template engine makes the admin unusable.