### PR TITLE
prevent tabular inline items from being moved beyond the last item

### DIFF
--- a/client/admin-sortable2.ts
+++ b/client/admin-sortable2.ts
@@ -1,4 +1,4 @@
-import Sortable, { MultiDrag, SortableEvent } from 'sortablejs';
+import Sortable, { MoveEvent, MultiDrag, SortableEvent } from 'sortablejs';
 
 Sortable.mount(new MultiDrag());
 
@@ -220,6 +220,7 @@ class InlineSortable {
 				handle: 'td.original p',
 				draggable: 'tr',
 				onEnd: event => this.onEnd(),
+				onMove: event => this.onMove(event),
 			});
 		} else {
 			// stacked inline
@@ -252,6 +253,10 @@ class InlineSortable {
 				reorderInputElement.value = `${index + 1}`;
 			});
 		}
+	}
+
+	private onMove(event: MoveEvent) {
+		return event.related.classList.contains("has_original");
 	}
 
 	private move(target: EventTarget | null, direction: 'begin' | 'end') {


### PR DESCRIPTION
Before this proposed change it was possible in a tabular inline to move items beyond the last item, i.e. after the empty extra rows for new items or even after the row with the "Add another chapter" link. 

<table>
  <tr><th>BEFORE</th><th>AFTER</th>
  <tr>
    <td><video src="https://user-images.githubusercontent.com/57509/191942938-3d4db9ce-263c-454e-bfa2-045ab1e5e9ba.mov" controls></video></td>
    <td><video src="https://user-images.githubusercontent.com/57509/191943058-95e3acf2-ea47-4f80-8328-771fed6f7601.mov" controls></video></td>
  </tr>
</table>