### PR TITLE
reorder command without ordering Meta field

### DIFF
--- a/adminsortable2/management/commands/reorder.py
+++ b/adminsortable2/management/commands/reorder.py
@@ -17,10 +17,15 @@ class Command(BaseCommand):
             except ImportError:
                 raise CommandError('Unable to load model "%s"' % modelname)
 
-            if not hasattr(Model._meta, 'ordering') or len(Model._meta.ordering) == 0:
-                raise CommandError(f'Model "{modelname}" does not define field "ordering" in its Meta class')
+            try:
+                orderfield = Model._meta.ordering[0]
+            except IndexError:
+                try:
+                    orderfield = Model._ordering_sortable[0]
+                except AttributeError:
+                    raise CommandError(
+                        f'Model "{modelname}" does not define field "ordering" in its Meta class nor "_ordering_sortable" model attribute')
 
-            orderfield = Model._meta.ordering[0]
             if orderfield[0] == '-':
                 orderfield = orderfield[1:]
 

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -315,6 +315,15 @@ then apply the changes to the database using:
 .. note:: If you omit to prepopulate the ordering field with unique values, after adding that field
 	to an existing model, then attempting to reorder items in the admin interface will fail.
 
+If the model does not specify a default ordering field in its ``Meta`` class, define an 
+``_ordering_sortable`` attribute on the model to specify the ordering:
+
+.. code:: python
+
+    class Button(models.Model):
+        _ordering_sortable = ['weight']
+        # .../...
+		
 
 Note on unique indices on the ordering field
 ============================================


### PR DESCRIPTION
Some models want to order in the admin interface only, and not in Meta. This hacks allows to use an "_ordering_sortable" model attribute to specify the order, so that reorder command can do job anyway. Meta ordering takes the priority. I hope it's a clean approach.