### PR TITLE
Exclude testapp submodules from built packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     install_requires=[
         'Django>=4.0',
     ],
-    packages=find_packages(exclude=['client', 'testapp', 'docs']),
+    packages=find_packages(exclude=['client', 'testapp', 'testapp*', 'docs']),
     include_package_data=True,
     zip_safe=False,
 )


### PR DESCRIPTION
The controls in `MANIFEST.in` are unfortunately neither necessary nor sufficient to control the inclusion of files from the `testapp` directory in wheels built from the original source. Those are instead controlled by the packages listed in `setup.py`, as found by `find_packages`.

It is unclear to me why `find_packages` requires explicitly excluding both `'testapp'` and `'testapp*'` (either spelling on its own isn't sufficient to exclude both files in the `testapp` folder as well as those within subfolders), however from testing this combination has the desired effect.

Tested by manually installing locally built source and wheel distribution packages and verifying what files were included within `site-pacakges`.

Fixes https://github.com/jrief/django-admin-sortable2/issues/359