### PR TITLE
Update usage.rst to correct spelling of `recommended` and `django-admin-sortable2`

### DIFF
--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -43,7 +43,7 @@ sortable-admin mixin classes. The minimized version can be imported as
 Run the Demo App
 ================
 
-**django-admin-sotable2** is shipped with a demo app, which shall be used as a reference when
+**django-admin-sortable2** is shipped with a demo app, which shall be used as a reference when
 reporting bugs, proposing new features or to just get a quick first impression of this library.
 
 Follow these steps to run this demo app. Note that in addition to Python, you also need a recent

--- a/docs/source/usage.rst
+++ b/docs/source/usage.rst
@@ -60,7 +60,7 @@ Django. Use one of these models fields:
 * :class:`~django.db.models.PositiveSmallIntegerField` (recommended for small sets)
 * :class:`~django.db.models.SmallIntegerField`
 
-In addition to the reccomended fields, :class:`~django.db.models.DecimalField` or
+In addition to the recommended fields, :class:`~django.db.models.DecimalField` or
 :class:`~django.db.models.FloatField` may work, but haven't been testest.
 
 .. warning:: Do not make this field unique! See below why.


### PR DESCRIPTION
As mentioned in the contributing guide I don't think an issue is needed before this PR:  https://django-admin-sortable2.readthedocs.io/en/latest/contributing.html