### PR TITLE
change_list.html: fix compress command of django-compressor

### DIFF
--- a/adminsortable2/templates/adminsortable2/change_list.html
+++ b/adminsortable2/templates/adminsortable2/change_list.html
@@ -1,4 +1,4 @@
-{% extends base_change_list_template %}
+{% extends base_change_list_template|default:'admin/change_list.html' %}
 
 {% block extrahead %}
 	{{ block.super }}


### PR DESCRIPTION
The django-compress raises following errors during run of `compress` management command and also `compilescss` command of `django-sass-processor`:

```
Error parsing template adminsortable2/change_list.html: Invalid template name in 'extends' tag: ''. Got this from the 'base_change_list_template' variable.
```