### PR TITLE
Fix for getattr error in the admin

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -485,10 +485,11 @@ class CustomInlineFormSetMixin:
         """
         obj = super().save_new(form, commit=False)
 
-        order_field_value = getattr(obj, self.default_order_field, None)
-        if order_field_value is None or order_field_value >= 0:
-            max_order = self.get_max_order()
-            setattr(obj, self.default_order_field, max_order + 1)
+        if self.default_order_field:
+            order_field_value = getattr(obj, self.default_order_field, None)
+            if order_field_value is None or order_field_value >= 0:
+                max_order = self.get_max_order()
+                setattr(obj, self.default_order_field, max_order + 1)
         if commit:
             obj.save()
         # form.save_m2m() can be called via the formset later on


### PR DESCRIPTION
There's an error `getattr(): attribute name must be string` in the line of admin, it was failing to add django CMS plugins on a clean installation


![Screenshot by Dropbox Capture](https://github.com/jrief/django-admin-sortable2/assets/65971828/b6c2c1fc-4694-4681-80e3-8d90963548fe)
