### PR TITLE
fix index on parallel queries

### DIFF
--- a/adminsortable2/admin.py
+++ b/adminsortable2/admin.py
@@ -308,7 +308,7 @@ class SortableAdminMixin(SortableAdminBase):
 
         with transaction.atomic():
             try:
-                obj = model.objects.get(**obj_filters)
+                obj = model.objects.select_for_update().get(**obj_filters)
             except model.MultipleObjectsReturned:
 
                 # noinspection PyProtectedMember
@@ -318,7 +318,7 @@ class SortableAdminMixin(SortableAdminBase):
                     "to adjust this inconsistency."
                 )
 
-            move_qs = model.objects.filter(**move_filter).order_by(order_by)
+            move_qs = model.objects.select_for_update().filter(**move_filter).order_by(order_by)
             move_objs = list(move_qs)
             for instance in move_objs:
                 setattr(


### PR DESCRIPTION
# Fix sorting in parallel requests

## Problem:
When you draging several lines in few seconds and parallel request running to change position - its raise an unrepetable reading and the sort index in database became not unique. For example we have an table:

> a 1
> b 2
> c 3
> d 4
> e 5

and two parallel requests
- `POST` adminsortable2_update: startorder: 2, endorder: 4
- `POST` adminsortable2_update: startorder: 5, endorder: 3

after first requests table will be:
> a 1
> b 4
> c 2
> d 3
> e 5

after second request table will be:
> a 1
> b 4
> c 4
> d 5
> e 3

Problem is duplicating sort index `4` in table.
It apperas becouse second request had read table before changes from first query was applied - so second request moved `e` to 3d position and changed indexes for `d` and `c` as +1. 

## Solition
To avoid this case we will lock all the range of changable rows
